### PR TITLE
[UPDATE] standardize .vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-python.python", "ms-python.black-formatter"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: app.py",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/app.py",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: app.py",
+            "name": "Debug llm-streaming-client app.py",
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/app.py",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.defaultFormatter": "ms-python.black-formatter",
   "editor.formatOnSave": true,
-  "editor.formatOnPaste": true
+  "editor.formatOnPaste": true,
+  "window.title": "${rootName} — ${activeEditorShort}"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "ms-python.black-formatter",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true
+}


### PR DESCRIPTION
## 1. Summary
This PR standardizes the `.vscode` folder across all projects, providing consistent editor settings and extension recommendations for both React (JavaScript/TypeScript) and Python repositories.

## 2. Description
The purpose of this change is to unify the development environment configuration by introducing or updating the `.vscode` directory in all codebases. For React projects, the configuration enforces Prettier formatting and ESLint integration, while for Python projects, it ensures recommended extensions and formatting settings are applied. This helps all contributors work with the same code style and tooling, reducing friction and inconsistencies across teams and projects.

## 3. Features
- Adds or updates `.vscode/settings.json` and `.vscode/extensions.json` in all repositories.
- Enforces Prettier as the default formatter and enables format on save/paste for React projects.
- Recommends ESLint and Prettier extensions for React projects.
- Provides a separate, standardized configuration for Python projects (not shown here, but included in the PR).

## 4. Related Issue
Related to [CHATO-287](https://thubantech-team.atlassian.net/browse/CHATO-287).

## 5. Implementation Details

### Components
- **.vscode/settings.json**: Defines editor formatting and language-specific settings.
- **.vscode/extensions.json**: Lists recommended VS Code extensions for the project.
- (For Python projects) Equivalent `.vscode` files with Python-specific recommendations and settings.

## 6. Technology Stack
- Visual Studio Code (editor configuration)
- Prettier (code formatter)
- ESLint (linter for React/JS/TS projects)
- Python (for Python project settings)

## 7. Configuration Files
- `.vscode/settings.json`: Editor and formatter settings.
- `.vscode/extensions.json`: Recommended extensions for the project.

[CHATO-287]: https://thubantech-team.atlassian.net/browse/CHATO-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ