### PR TITLE
[UPDATE] Add session_id to MessageInputDTO and update request handling

### DIFF
--- a/src/llm_streaming_client/adapter/server_request_adapter.py
+++ b/src/llm_streaming_client/adapter/server_request_adapter.py
@@ -4,6 +4,7 @@ from ..config.config import CONFIG
 from ..dtos.input import MessageInputDTO
 from ..adapter.exceptions import RequestHandlingException
 
+
 class ServerRequestAdapter(HttpClient):
     """Adapter to interact with the request handling microservice paths."""
 
@@ -11,7 +12,7 @@ class ServerRequestAdapter(HttpClient):
         super().__init__(timeout=timeout)
         self._config = CONFIG.server_request_adapter
         self.base_url = base_url
- 
+
     def handle_request(self, dto: MessageInputDTO) -> Dict[str, Any]:
         """
         Sends a request to the LLM service and retrieves the response.
@@ -22,6 +23,7 @@ class ServerRequestAdapter(HttpClient):
             llm_name: The name of the LLM to use (default: "openai").
             model_name: The name of the model to use (default: "gpt-4o-mini").
             image_object: Optional image object for the request.
+            session_id: Optional session ID for the request.
 
         Returns:
             A dictionary containing the response from the LLM service.
@@ -36,6 +38,8 @@ class ServerRequestAdapter(HttpClient):
             }
             if dto.image_object:
                 data["image"] = dto.image_object
+            if dto.session_id:
+                data["session_id"] = dto.session_id
 
             url = self.base_url + self._config["request"]
             return self._post(url, json=data)

--- a/src/llm_streaming_client/client.py
+++ b/src/llm_streaming_client/client.py
@@ -7,9 +7,11 @@ from .adapter.socket_client import SocketAdapter
 from typing import Dict, Any, Optional
 from .config.config import CONFIG
 from .dtos.output import (
-    StatusOutputDTO, AvailableModelsOutputDTO, 
-    AvailableLLMsOutputDTO, AvailablePromptsOutputDTO,
-    AudioTranscriptionOutputDTO
+    StatusOutputDTO,
+    AvailableModelsOutputDTO,
+    AvailableLLMsOutputDTO,
+    AvailablePromptsOutputDTO,
+    AudioTranscriptionOutputDTO,
 )
 from .dtos.input import StreamingInputDTO, MessageInputDTO
 from .dtos.core_dto import EMessageType
@@ -22,18 +24,24 @@ from .dtos.core_dto import IMessage
 class LLMStreamingClient:
     """Simplified client for the llm_streaming."""
 
-    def __init__(self, base_url: Optional[str] = CONFIG.BASE_URL, timeout: int = CONFIG.TIMEOUT) -> None:
+    def __init__(
+        self, base_url: Optional[str] = CONFIG.BASE_URL, timeout: int = CONFIG.TIMEOUT
+    ) -> None:
         """
         Initialize the client.
-        
+
         Args:
             base_url: Base URL of the service
             timeout: Maximum wait time for requests
         """
         self.base_url = base_url
         self.config_adapter = ConfigAdapter(timeout=timeout, base_url=self.base_url)
-        self.config_audio_adapter = ConfigAudioAdapter(timeout=timeout, base_url=self.base_url)
-        self.server_request_adapter = ServerRequestAdapter(timeout=timeout, base_url=self.base_url)
+        self.config_audio_adapter = ConfigAudioAdapter(
+            timeout=timeout, base_url=self.base_url
+        )
+        self.server_request_adapter = ServerRequestAdapter(
+            timeout=timeout, base_url=self.base_url
+        )
         self.socket_adapter = SocketAdapter(timeout=timeout, base_url=self.base_url)
 
     def get_status(self) -> StatusOutputDTO:
@@ -71,8 +79,10 @@ class LLMStreamingClient:
             List of dictionaries containing prompt metadata.
         """
         return self.config_adapter.get_available_prompts()
-    
-    def transcribe_audio(self, audio_service: str, audio_url: str) -> AudioTranscriptionOutputDTO:
+
+    def transcribe_audio(
+        self, audio_service: str, audio_url: str
+    ) -> AudioTranscriptionOutputDTO:
         """
         Transcribe an audio file using the specified audio service.
 
@@ -84,7 +94,7 @@ class LLMStreamingClient:
             A dictionary containing the transcription result.
         """
         return self.config_audio_adapter.transcribe_audio(audio_service, audio_url)
-    
+
     def handle_request(
         self,
         text: str,
@@ -93,6 +103,7 @@ class LLMStreamingClient:
         model_name: str = "gpt-4o-mini",
         language: LanguageEnum = LanguageEnum.SPANISH,
         image_object: Optional[Any] = None,
+        session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Handle a request to the LLM service.
@@ -103,6 +114,7 @@ class LLMStreamingClient:
             llm_name: The name of the LLM to use (default: "openai").
             model_name: The name of the model to use (default: "gpt-4o-mini").
             image_object: Optional image object for the request.
+            session_id: Optional session ID for the request.
 
         Returns:
             A dictionary containing the response from the LLM service.
@@ -111,12 +123,17 @@ class LLMStreamingClient:
             llm_name=llm_name,
             model_name=model_name,
             text=text or "",
-            language=(LanguageEnum(language) if isinstance(language, str) else language),
-            action_key=(ActionKeys(action_key) if isinstance(action_key, str) else action_key),
+            language=(
+                LanguageEnum(language) if isinstance(language, str) else language
+            ),
+            action_key=(
+                ActionKeys(action_key) if isinstance(action_key, str) else action_key
+            ),
             image_object=image_object,
+            session_id=session_id,
         )
         return self.server_request_adapter.handle_request(dto)
-    
+
     def send_messages_via_socket(
         self,
         messages: List[Dict[str, Any]],
@@ -149,13 +166,12 @@ class LLMStreamingClient:
             for m in messages
         ]
         dto = StreamingInputDTO(
-                    llm_name=llm,
-                    model_name=model,
-                    messages=imessages,
-                    prompt=prompt,      
-                    language=language,
-                    action_key=action_key,
-                    image_object=image_object,
-                )
+            llm_name=llm,
+            model_name=model,
+            messages=imessages,
+            prompt=prompt,
+            language=language,
+            action_key=action_key,
+            image_object=image_object,
+        )
         self.socket_adapter.send_messages(dto)
-    

--- a/src/llm_streaming_client/dtos/input.py
+++ b/src/llm_streaming_client/dtos/input.py
@@ -36,3 +36,4 @@ class MessageInputDTO:
     language: LanguageEnum
     action_key: ActionKeys
     image_object: Optional[str] = None
+    session_id: Optional[str] = None


### PR DESCRIPTION
## 1. Summary
This PR adds support for the `session_id` parameter in the client library, allowing session tracking for LLM requests. The change affects the DTOs, client interface, and request adapter.

## 2. Description
The update enables the `llm-streaming-client` to handle session-based interactions by introducing an optional `session_id` field. This allows clients to associate requests with specific sessions, improving context management and traceability when interacting with the LLM_Streaming backend. The change is integrated across the data transfer objects, the main client class, and the server request adapter to ensure end-to-end support.

## 3. Features
- Adds `session_id` as an optional field in `MessageInputDTO`.
- Updates `LLMStreamingClient.handle_request` to accept and forward `session_id`.
- Modifies `ServerRequestAdapter` to include `session_id` in outgoing requests if provided.

## 4. Related Issue
Related to [CHATO-358](https://thubantech-team.atlassian.net/browse/CHATO-358).

## 5. Implementation Details

### Endpoints
- No new endpoints are introduced; the client continues to interact with existing LLM_Streaming endpoints, now supporting session-aware requests.

### Components
- **dtos/input.py**: Adds `session_id` to `MessageInputDTO`.
- **client.py**: Updates the `handle_request` method to accept and pass `session_id`.
- **adapter/server_request_adapter.py**: Modifies the request payload to include `session_id` when present.

## 6. Technology Stack
- Python 3.9+
- requests
- python-socketio
- dataclasses

## 7. Configuration Files
- `src/llm_streaming_client/dtos/input.py`: DTO definition updated.
- `src/llm_streaming_client/client.py`: Client logic updated.
- `src/llm_streaming_client/adapter/server_request_adapter.py`: Adapter logic updated.

[CHATO-358]: https://thubantech-team.atlassian.net/browse/CHATO-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ