### PR TITLE
Am/chato 374.separate user message and context

### DIFF
--- a/src/llm_streaming_client/adapter/server_request_adapter.py
+++ b/src/llm_streaming_client/adapter/server_request_adapter.py
@@ -33,7 +33,6 @@ class ServerRequestAdapter(HttpClient):
                 "llm_name": dto.llm_name,
                 "model_name": dto.model_name,
                 "text": dto.text,
-                "context_info": dto.context_info,
                 "language": dto.language.value,
                 "actionKey": dto.action_key.value,
             }
@@ -41,6 +40,8 @@ class ServerRequestAdapter(HttpClient):
                 data["image"] = dto.image_object
             if dto.session_id:
                 data["session_id"] = dto.session_id
+            if dto.context_info:
+                data["context_info"] = dto.context_info
 
             url = self.base_url + self._config["request"]
             return self._post(url, json=data)

--- a/src/llm_streaming_client/adapter/server_request_adapter.py
+++ b/src/llm_streaming_client/adapter/server_request_adapter.py
@@ -33,6 +33,7 @@ class ServerRequestAdapter(HttpClient):
                 "llm_name": dto.llm_name,
                 "model_name": dto.model_name,
                 "text": dto.text,
+                "context": dto.context,
                 "language": dto.language.value,
                 "actionKey": dto.action_key.value,
             }

--- a/src/llm_streaming_client/adapter/server_request_adapter.py
+++ b/src/llm_streaming_client/adapter/server_request_adapter.py
@@ -33,7 +33,7 @@ class ServerRequestAdapter(HttpClient):
                 "llm_name": dto.llm_name,
                 "model_name": dto.model_name,
                 "text": dto.text,
-                "context": dto.context,
+                "context_info": dto.context_info,
                 "language": dto.language.value,
                 "actionKey": dto.action_key.value,
             }

--- a/src/llm_streaming_client/client.py
+++ b/src/llm_streaming_client/client.py
@@ -124,7 +124,7 @@ class LLMStreamingClient:
             llm_name=llm_name,
             model_name=model_name,
             text=text or "",
-            context_info=context_info or "",
+            context_info=context_info,
             language=(
                 LanguageEnum(language) if isinstance(language, str) else language
             ),

--- a/src/llm_streaming_client/client.py
+++ b/src/llm_streaming_client/client.py
@@ -102,6 +102,7 @@ class LLMStreamingClient:
         llm_name: str = "openai",
         model_name: str = "gpt-4o-mini",
         language: LanguageEnum = LanguageEnum.SPANISH,
+        context_info: Optional[str] = None,
         image_object: Optional[Any] = None,
         session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
@@ -123,6 +124,7 @@ class LLMStreamingClient:
             llm_name=llm_name,
             model_name=model_name,
             text=text or "",
+            context_info=context_info or "",
             language=(
                 LanguageEnum(language) if isinstance(language, str) else language
             ),

--- a/src/llm_streaming_client/dtos/input.py
+++ b/src/llm_streaming_client/dtos/input.py
@@ -33,8 +33,8 @@ class MessageInputDTO:
     llm_name: str
     model_name: str
     text: str
-    context_info: Optional[str] = None
     language: LanguageEnum
     action_key: ActionKeys
+    context_info: Optional[str] = None
     image_object: Optional[str] = None
     session_id: Optional[str] = None

--- a/src/llm_streaming_client/dtos/input.py
+++ b/src/llm_streaming_client/dtos/input.py
@@ -33,6 +33,7 @@ class MessageInputDTO:
     llm_name: str
     model_name: str
     text: str
+    context: Optional[str] = None
     language: LanguageEnum
     action_key: ActionKeys
     image_object: Optional[str] = None

--- a/src/llm_streaming_client/dtos/input.py
+++ b/src/llm_streaming_client/dtos/input.py
@@ -33,7 +33,7 @@ class MessageInputDTO:
     llm_name: str
     model_name: str
     text: str
-    context: Optional[str] = None
+    context_info: Optional[str] = None
     language: LanguageEnum
     action_key: ActionKeys
     image_object: Optional[str] = None


### PR DESCRIPTION
## 1. Summary

This PR updates the LLM streaming client library to support sending user messages and context separately in the request payload, matching the new backend and frontend structure.

## 2. Description

The client library now allows the `handle_request` method to accept both a pure user message (`text`) and additional context (`context_info`) as distinct fields. The DTOs, adapter, and client logic have been updated to forward these fields to the backend, ensuring compatibility with the new payload structure and Langchain memory handling.

## 3. Features

- Supports a new `context_info` field in the request DTO and payload.
- Forwards both `text` and `context_info` to the backend service.
- Maintains backward compatibility for other fields (image, session, etc.).

## 4. Related Issue

Related to [CHATO-374](https://thubantech-team.atlassian.net/browse/CHATO-374).

## 5. Implementation Details

**Endpoints:**
- The adapter sends requests to the backend's `/request` endpoint, now including `context_info` if provided.

**Components:**
- `MessageInputDTO` (`dtos/input.py`): Now includes an optional `context_info` field.
- `ServerRequestAdapter` (`adapter/server_request_adapter.py`): Adds `context_info` to the outgoing payload if present.
- `LLMStreamingClient` (`client.py`): Accepts and forwards `context_info` in the `handle_request` method.

## 6. Technology Stack

- Python
- Requests/HTTP client

## 7. Configuration Files

- `src/llm_streaming_client/dtos/input.py`: DTO definition updated.
- `src/llm_streaming_client/adapter/server_request_adapter.py`: Adapter logic updated.
- `src/llm_streaming_client/client.py`: Client

[CHATO-374]: https://thubantech-team.atlassian.net/browse/CHATO-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ